### PR TITLE
Update 'not_found' messages in German

### DIFF
--- a/de.json
+++ b/de.json
@@ -10,16 +10,16 @@
     "footer_documents": "Dokumentation",
     "footer_github": "Github",
     "footer_discord": "Discord",
-    "footer_info/status": "Status",
+    "footer_info/status": "Info/Status",
 
 
     "not_found": "404 Nicht gefunden 🙀",
-    "not_found_message": "Was zum henker suchst du?",
-    "not_found_message2": "ich empfehle dir zur hauptseite zurückzukehren :)",
+    "not_found_message": "Was du gerade versuchst zu finden, existiert nicht. 😿",
+    "not_found_message2": "Hier wurde nichts gefunden. Geh am besten zurück zur Hauptseite. 😽",
     "return_to_main_page": "Zurück zur Hauptseite",
 
     "oops": "Ups...",
-    "search_results_do_not_exist": "Suchergebnisse existieren nicht :(",
+    "search_results_do_not_exist": "Unsere Katzen suchten überall, aber konnten dennoch nichts finden. 😥",
 
     "loading": "Lade...",
     "loaded": "Geladen!",

--- a/de.json
+++ b/de.json
@@ -19,7 +19,7 @@
     "return_to_main_page": "Zurück zur Hauptseite",
 
     "oops": "Ups...",
-    "search_results_do_not_exist": "Unsere Katzen suchten überall, aber konnten dennoch nichts finden. 😥",
+    "search_results_do_not_exist": "Unsere Katzen suchten überall, aber konnten trotzdem nichts finden. 😥",
 
     "loading": "Lade...",
     "loaded": "Geladen!",


### PR DESCRIPTION
I've noticed that the 404 messages got updated and I wanted to change them in German as well.

Let me try to directly translate the sentences:

- "not_found_message": "What you are currently trying to search doesn't exist."
- "not_found_message_2": "Nothing was found here. Just go back to the main page."
- "search_results_do_not_exist": "Our cats looked everywhere but couldn't find anything."

I tried to give the sentences a bit more "casual" feeling, if that makes sense.